### PR TITLE
Replaced button to 'shoppingCart.js', disabled and enabled state

### DIFF
--- a/src/main/resources/static/js/user/order/shoppingCart.js
+++ b/src/main/resources/static/js/user/order/shoppingCart.js
@@ -73,12 +73,18 @@ async function getShoppingCart() {
                     $('#shoppingCardOrderDisabledMessage').addClass('resolveShopCart').text('Please resolve shopping cart warnings before proceeding');
                     $('#forButtonCheckout').html(`<div><button class="btn btn-primary checkout-btn" id="chechout" onclick="confirmAddress()" type="button" disabled="disabled">
                                     Checkout
-                                </button></div>`)
+                                </button></div>`);
+                    $('#for-1click-reg').html(`<button class="btn btn-primary" id="1click-reg-btn"
+                                               onclick="location.href='/1clickreg'" type="button" disabled="disabled">
+                                               Buy without sign up</button>`);
                 } else {
                     $('#shoppingCardOrderDisabledMessage').text('');
                     $('#forButtonCheckout').html(`<div><button class="btn btn-primary checkout-btn" id="chechout" onclick="confirmAddress()" type="button">
                                     Checkout
-                                </button></div>`)
+                                </button></div>`);
+                    $('#for-1click-reg').html(`<button class="btn btn-primary" id="1click-reg-btn"
+                                               onclick="location.href='/1clickreg'" type="button">
+                                               Buy without sign up</button>`);
                 }
           setLocaleFields();
 

--- a/src/main/resources/templates/cabinet.html
+++ b/src/main/resources/templates/cabinet.html
@@ -364,9 +364,7 @@
                             <th></th>
                             <th id="shoppingCardOrderDisabledMessage"></th>
 
-                            <th sec:authorize="!isAuthenticated()"><button class="btn btn-primary" id="1click-reg-btn" onclick="location.href='/1clickreg'" type="button">
-                            Buy without sign up
-                        </button></th>
+                            <th id="for-1click-reg" sec:authorize="!isAuthenticated()"></th>
                             <th id="forButtonCheckout">
                             </th>
                         </tr>


### PR DESCRIPTION
HTML-код вынес в JS, где уже было отработано условие блокировки кнопки "Checkout".
Соответственно, два состояния: при пустой корзине кнопка "Buy without sign up" неактивна для нажатия.