### PR TITLE
fix-main-search-filter

### DIFF
--- a/src/main/java/com/project/dao/BookDaoImpl.java
+++ b/src/main/java/com/project/dao/BookDaoImpl.java
@@ -56,7 +56,7 @@ public class BookDaoImpl extends AbstractDao<Long, Book> implements BookDao {
                                                     Long pagesFrom, Long pagesTo, String searchBy, List<Long> categories, Pageable pageable, boolean isShow) {
         int limitBookDTOOnPage = pageable.getPageSize();
         int minNumberId = limitBookDTOOnPage * pageable.getPageNumber();
-        long amountOfBooks = getQuantityBooksBySearchRequest(request, priceFrom, priceTo, yearOfEditionFrom, yearOfEditionTo, pagesFrom, pagesTo, searchBy, categories);
+        long amountOfBooks = getQuantityBooksBySearchRequest(request, priceFrom, priceTo, yearOfEditionFrom, yearOfEditionTo, pagesFrom, pagesTo, searchBy, categories, isShow);
         String name = ("%" + request + "%");
         String hql = ("SELECT new com.project.model.BookNewDTO(b.id, b.originalLanguage.name," +
                 "b.originalLanguage.nameTranslit, b.originalLanguage.author, b.originalLanguage.authorTranslit, b.description.en," +
@@ -101,11 +101,12 @@ public class BookDaoImpl extends AbstractDao<Long, Book> implements BookDao {
 
     @Override
     public long getQuantityBooksBySearchRequest(String request, Long priceFrom, Long priceTo,
-                                                String yearOfEditionFrom, String yearOfEditionTo, Long pagesFrom, Long pagesTo, String searchBy, List<Long> categories) {
+                                                String yearOfEditionFrom, String yearOfEditionTo,
+                                                Long pagesFrom, Long pagesTo, String searchBy, List<Long> categories, boolean isShow) {
         String name = ("%" + request + "%");
         //todo число книг диз энд эвэл
         String hql = ("SELECT new com.project.model.BookNewDTO(b.id)" +
-                "FROM Book b where b.isShow = true AND " +
+                "FROM Book b where (b.isShow = true or b.isShow = :isShow) AND " +
                 "(((LOWER(b.originalLanguage.name) LIKE  :name or LOWER(b.originalLanguage.nameTranslit)  LIKE :name or " +
                 "LOWER(b.originalLanguage.author) LIKE :name or LOWER(b.originalLanguage.authorTranslit) LIKE :name) and :searchBy = 'name-author') OR" +
                 "((LOWER(b.originalLanguage.name) LIKE :name or LOWER(b.originalLanguage.nameTranslit) LIKE :name) and :searchBy = 'name') OR" +
@@ -127,6 +128,7 @@ public class BookDaoImpl extends AbstractDao<Long, Book> implements BookDao {
                 .setParameter("priceTo", priceTo)
                 .setParameter("categories", categories)
                 .setParameter("searchBy", searchBy)
+                .setParameter("isShow", isShow)
                 .getResultList();
         return Long.valueOf(list.size());
     }

--- a/src/main/java/com/project/dao/abstraction/BookDao.java
+++ b/src/main/java/com/project/dao/abstraction/BookDao.java
@@ -10,7 +10,8 @@ public interface BookDao extends GenericDao<Long, Book> {
     List<BookDTO> get20BookDTO(String locale);
 
     long getQuantityBooksBySearchRequest(String request, Long priceFrom, Long priceTo,
-                                         String yearOfEditionFrom, String yearOfEditionTo, Long pagesFrom, Long pagesTo, String searchBy, List<Long> categories);
+                                         String yearOfEditionFrom, String yearOfEditionTo,
+                                         Long pagesFrom, Long pagesTo, String searchBy, List<Long> categories, boolean isShow);
 
     List<BookNewDTO> getBookBySearchRequest(String req, boolean isShow);
 

--- a/src/main/resources/static/js/utils/search.js
+++ b/src/main/resources/static/js/utils/search.js
@@ -25,13 +25,10 @@ $(document).ready(async function () {
 });
 
 async function getQuantityPage() {
-        const url = '/getPageBooks';
-        const res = await fetch(url);
-        const data = await res.json();
-        if (data.length < amountBooksInPage) {
+        if (amountBooksInDb < amountBooksInPage) {
             return 1;
         }
-        return Math.ceil(data.length / amountBooksInPage);
+        return Math.ceil(amountBooksInDb / amountBooksInPage);
 }
 
 async function addPagination() {
@@ -100,8 +97,8 @@ function setListeners () {
     $('#search-submit').on('click', () => {
         currentPage = 0;
         advancedSearch(ddmAmountBook.text(), currentPage++);
-        $('#input-categories').empty();
-        getCategoryTree();
+        getCategoryTreeWithoutRefreshing();
+        addPagination();
     });
 
     $('#input-categories').on('click', '.custom-control-input', function () {
@@ -203,7 +200,7 @@ async function setTreeViewWithoutRefreshing(categories) {
                     </label>
                 </div>`;
         if (category.childrens != undefined) {
-            console.log( ":    " + category.childrens);
+            // console.log( ":    " + category.childrens);
             row +=
                 `<div class="ml-3">
                     <div id="collapse-${category.id}" class="collapse" data-parent="#accordion" aria-labelledby="heading-${category.id}">
@@ -270,7 +267,7 @@ function getUnflatten(arr, parentid) {
 async function setTreeView(categories) {
 
     for (let category of categories) {
-        console.log( category.id + ":    " + category.categoryName);
+        // console.log( category.id + ":    " + category.categoryName);
         row =
             `<div id="${category.id}" class="category text-nowrap">
                 <div class="custom-control custom-checkbox form-check-inline" id="heading-${category.id}">
@@ -282,7 +279,7 @@ async function setTreeView(categories) {
                     </label>
                 </div>`;
         if (category.childrens != undefined) {
-            console.log( ":    " + category.childrens);
+            // console.log( ":    " + category.childrens);
             row +=
                 `<div class="ml-3">
                     <div id="collapse-${category.id}" class="collapse" data-parent="#accordion" aria-labelledby="heading-${category.id}">
@@ -300,9 +297,9 @@ async function setTreeView(categories) {
 
 async function setChilds(categories) {
     let row = '';
-    console.log( ":    " + categories);
+    // console.log( ":    " + categories);
     for (let category of categories) {
-        console.log( "child: " + category.id + ":    " + category.categoryName + " " + category.childrens);
+        // console.log( "child: " + category.id + ":    " + category.categoryName + " " + category.childrens);
         if (category.childrens === undefined) {
             row +=
                 `<div class="category text-nowrap">


### PR DESCRIPTION
1. Изменил некорректный запрос к БД о количестве книг (всегда выдавал 12).
2. Исправил сброс чек-боксов при выборе категории, использовал существующий метод отрисовки без перезагрузки страницы.
3. Пагинацию привязал к исправленному сервису, убрал лишний запрос к контроллеру.
Теперь количество страниц отображается в соответствии с поисковым запросом.